### PR TITLE
widen sbp version constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ crossbeam-utils = "0.8"
 log = "0.4"
 once_cell = "1"
 parking_lot = "0.11"
-sbp = { version = "4.0.1", features = ["link"] }
+sbp = { version = "4", features = ["link"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 


### PR DESCRIPTION
To avoid compiling sbp twice/possible version mismatch errors