### PR TITLE
add read_all_timeout/fix double free

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -128,7 +128,7 @@ impl<'a> Client<'a> {
                 }
             });
             let res = self.read_all_inner(stop_r);
-            done_s.send(()).unwrap();
+            let _ = done_s.send(());
             res
         })
         .unwrap()

--- a/src/client.rs
+++ b/src/client.rs
@@ -173,6 +173,8 @@ impl<'a> Client<'a> {
                     }
                 });
             }
+            // we need to drop these before calling `.iter()` to disconnect the channels
+            // otherwise `.iter()` will never terminate
             drop(idx_r);
             drop(settings_s);
             drop(errors_s);


### PR DESCRIPTION
Double free was causing a panic/crash in the console. Also adds a read_all_timeout method so in the console we can make sure it never hangs reading