### PR TITLE
Pick-up git submodule changes faster

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
+ Dial up submodule update frequency so changes like @sokhealy's will get picked up faster
+ Dial down Rust dependency updates since these can be noisy (case in point is clap currently)