### PR TITLE
Make SettingValue::Integer a long [CPP-616]

### DIFF
--- a/src/setting.rs
+++ b/src/setting.rs
@@ -177,7 +177,7 @@ impl SettingKind {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SettingValue {
-    Integer(i32),
+    Integer(i64),
     Boolean(bool),
     Float(f32),
     String(String),


### PR DESCRIPTION
`serial_number` is an integer setting that does not fit into
an i32.