### PR TITLE
Adds a timeout to settings writes to prevent lockup.[CPP-614]

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -73,7 +73,7 @@ impl<'a> Client<'a> {
         name: impl Into<String>,
         value: impl Into<String>,
     ) -> Result<Entry, Error> {
-        let (ctx, _ctx_handle) = Context::new();
+        let (ctx, _ctx_handle) = Context::with_timeout(Duration::from_millis(100));
         self.write_setting_ctx(group, name, value, ctx)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,7 @@ use crate::setting::{Setting, SettingValue};
 
 const SENDER_ID: u16 = 0x42;
 const NUM_WORKERS: usize = 10;
+const SETTINGS_WRITE_TIMEOUT_MS: u64 = 1000;
 
 pub struct Client<'a> {
     link: Link<'a, ()>,
@@ -73,7 +74,8 @@ impl<'a> Client<'a> {
         name: impl Into<String>,
         value: impl Into<String>,
     ) -> Result<Entry, Error> {
-        let (ctx, _ctx_handle) = Context::with_timeout(Duration::from_millis(100));
+        let (ctx, _ctx_handle) =
+            Context::with_timeout(Duration::from_millis(SETTINGS_WRITE_TIMEOUT_MS));
         self.write_setting_ctx(group, name, value, ctx)
     }
 


### PR DESCRIPTION
In the console when switching ethernet modes DHCP <-> Static, once the user switches the new changes to Active, a write gets initiated but never completes. This was locking up the main process_messages loop from exiting and hanging the app. This may additionally resolve some other connectivity issues we have been experiencing but I haven't verified this yet.