### PR TITLE
Uprev libsettings, release 0.6.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbp-settings"
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Swift Navigation <dev@swift-nav.com>"]
 edition = "2018"
 description = "SwiftNav settings API library"


### PR DESCRIPTION
* Uprev libsettings to include serial_number -> string
* Uprev Cargo toml release to 0.6.11
![Screen Shot 2022-07-02 at 6 02 35 AM](https://user-images.githubusercontent.com/43353147/177002027-10b5a1f2-91ab-42b6-90ec-23b2b4aae8f6.png)
