### PR TITLE
Support for Entry::try_from w/o fmt_type, and release 0.6.12[CPP-788]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbp-settings"
-version = "0.6.11"
+version = "0.6.12"
 authors = ["Swift Navigation <dev@swift-nav.com>"]
 edition = "2018"
 description = "SwiftNav settings API library"

--- a/src/client.rs
+++ b/src/client.rs
@@ -332,6 +332,11 @@ impl TryFrom<MsgSettingsReadByIndexResp> for Entry {
                 let value = SettingValue::parse(value, setting.kind);
                 Ok(Entry { setting, value })
             }
+            [group, name, value] => {
+                let setting = Setting::new(group, name);
+                let value = SettingValue::parse(value, setting.kind);
+                Ok(Entry { setting, value })
+            }
             _ => Err(Error::ParseError),
         }
     }


### PR DESCRIPTION
* Support for Entry::try_from<MsgSettingReadByIndexResp> w/o fmt_type.
* Release 0.6.12