### PR TITLE
Add support for doubles.[CPP-795]

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -492,6 +492,26 @@ mod tests {
     }
 
     #[test]
+    fn mock_read_setting_float() {
+        let (group, name) = ("ins", "filter_vel_half_life_alpha");
+        let mut mock = Mock::new();
+        mock.req_reply(
+            MsgSettingsReadReq {
+                sender_id: Some(SENDER_ID),
+                setting: SbpString::from(format!("{}\0{}\0", group, name)),
+            },
+            MsgSettingsReadResp {
+                sender_id: Some(SENDER_ID),
+                setting: SbpString::from(format!("{}\0{}\00.1\0", group, name)),
+            },
+        );
+        let (reader, writer) = mock.into_io();
+        let mut client = Client::new(reader, writer);
+        let response = client.read_setting(group, name).unwrap().unwrap();
+        assert_eq!(response.value, Some(SettingValue::Float(0.1)));
+    }
+
+    #[test]
     fn mock_read_setting_double() {
         let (group, name) = ("surveyed_position", "surveyed_lat");
         let mut mock = Mock::new();

--- a/src/client.rs
+++ b/src/client.rs
@@ -508,7 +508,7 @@ mod tests {
         let (reader, writer) = mock.into_io();
         let mut client = Client::new(reader, writer);
         let response = client.read_setting(group, name).unwrap().unwrap();
-        assert_eq!(response.value, Some(SettingValue::Float(0.1)));
+        assert_eq!(response.value, Some(SettingValue::Double(0.1)));
     }
 
     #[test]

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -180,6 +180,7 @@ pub enum SettingValue {
     Integer(i64),
     Boolean(bool),
     Float(f32),
+    Double(f64),
     String(String),
 }
 
@@ -192,7 +193,8 @@ impl SettingValue {
             SettingKind::Integer => v.parse().ok().map(SettingValue::Integer),
             SettingKind::Boolean if v == "True" => Some(SettingValue::Boolean(true)),
             SettingKind::Boolean if v == "False" => Some(SettingValue::Boolean(false)),
-            SettingKind::Float | SettingKind::Double => v.parse().ok().map(SettingValue::Float),
+            SettingKind::Float => v.parse().ok().map(SettingValue::Float),
+            SettingKind::Double => v.parse().ok().map(SettingValue::Double),
             SettingKind::String | SettingKind::Enum | SettingKind::PackedBitfield => {
                 Some(SettingValue::String(v.to_owned()))
             }
@@ -210,6 +212,7 @@ impl fmt::Display for SettingValue {
             SettingValue::Boolean(true) => write!(f, "True"),
             SettingValue::Boolean(false) => write!(f, "False"),
             SettingValue::Float(s) => s.fmt(f),
+            SettingValue::Double(s) => s.fmt(f),
             SettingValue::String(s) => s.fmt(f),
         }
     }


### PR DESCRIPTION
Breaks up SettingsValue::Float and SettingsValue::Double to separate variants corresponding to f32 and f64, respectively.


@notoriaga Was there a specific reason we were doing this?