### PR TITLE
Uprev deprecated operating systems.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             binary_target: x86_64-unknown-linux-musl
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             binary_target: x86_64-unknown-linux-gnu
-          - os: macos-10.15
+          - os: macos-11
             binary_target: x86_64-apple-darwin
           - os: windows-2019
             binary_target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Scheduled deprecations for ubuntu-18 and macos-15 are causing CI to fail.